### PR TITLE
support arbitrary filters for series endpoint

### DIFF
--- a/marvelous/session.py
+++ b/marvelous/session.py
@@ -76,11 +76,21 @@ class Session():
         return comics_list.ComicsList(
             self.call(['comics'], params=params))
 
-    def series(self, _id):
-        result = series.SeriesSchema().load(self.call(['series', _id]))
-
-        if len(result.errors) > 0:
-            raise exceptions.ApiError(result.errors)
-
-        result.data.session = self
-        return result.data
+    def series(self, _id=None, params=None):
+        result = None
+        if _id:
+            result = series.SeriesSchema().load(self.call(['series', _id]))
+            result.data.session = self
+            if len(result.errors) > 0:
+                raise exceptions.ApiError(result.errors)
+            return result.data
+        elif params:
+            result, errors = series.SeriesSchema().load(
+                self.call(['series'], params).get('data', {}).get('results',[]),
+                many=True
+            )
+            if len(errors) > 0:
+                raise exceptions.ApiError(errors)
+            for r in result:
+                r.session = self
+            return result

--- a/tests/series_test.py
+++ b/tests/series_test.py
@@ -3,6 +3,7 @@ import unittest
 
 import marvelous
 from marvelous.comics_list import ComicsList
+from marvelous.series import Series
 
 
 class TestSeries(unittest.TestCase):
@@ -30,6 +31,19 @@ class TestSeries(unittest.TestCase):
     def test_bad_response_data(self):
         with self.assertRaises(marvelous.exceptions.ApiError):
             ComicsList({'data': {'results': [{'modified': 'potato'}]}})
+
+    def test_all_series(self):
+        # check known values
+        series_single = self.m.series(
+            params={'title':"Ultimate Spider-Man"})  # don't include '(year - year)', it doesn't work
+        series_list = list(series_single)  # unspool the iterator
+        self.assertIsNotNone(series_single)
+        self.assertEqual(1, len(series_list))
+        self.assertIsInstance(series_list[0], Series)
+        # check the iterator works
+        series_iter = self.m.series(params={'type':'ongoing', 'limit':10})
+        for series in series_iter:
+            self.assertIsInstance(series, Series)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This addition is backward-compatible and adds support for retrieving multiple Series objects via filters.