### PR TITLE
Add support for comics prices

### DIFF
--- a/marvelous/comic.py
+++ b/marvelous/comic.py
@@ -1,6 +1,6 @@
 from marshmallow import INCLUDE, Schema, fields, post_load, pre_load
 
-from . import character, creator, dates, events, series, urls
+from . import character, creator, dates, events, prices, series, urls
 
 
 class Comic:
@@ -32,7 +32,7 @@ class ComicSchema(Schema):
     # collections
     # collectedIssues
     dates = fields.Nested(dates.DatesSchema)
-    # prices
+    prices = fields.Nested(prices.PriceSchemas, allow_none=True)
     # thumbnail
     images = fields.List(fields.Url)
     creators = fields.Nested(creator.CreatorsSchema, many=True)

--- a/marvelous/prices.py
+++ b/marvelous/prices.py
@@ -1,0 +1,34 @@
+from marshmallow import INCLUDE, Schema, fields, post_load, pre_load
+
+
+class Prices:
+    def __init__(self, print=None, **kwargs):
+        self.print = print
+        self.unknown = kwargs
+
+
+class PriceSchemas(Schema):
+    printPrice = fields.Float(attribute="print")
+
+    # Supposedly digital prices could also be listed, but I
+    # couldn't find any refences so made a guess what I thought
+    # it would be. I'll leave it here in case we need it in the
+    # future.
+
+    # digitalPrice = fields.Float(attribute="digital")
+
+    class Meta:
+        unknown = INCLUDE
+
+    @pre_load
+    def process_input(self, data, **kwargs):
+        new_data = {}
+        for idx, d in enumerate(data, 0):
+            if d["type"][idx]:
+                new_data[d["type"]] = d["price"]
+
+        return new_data
+
+    @post_load
+    def make(self, data, **kwargs):
+        return Prices(**data)

--- a/tests/comic_test.py
+++ b/tests/comic_test.py
@@ -49,11 +49,13 @@ class TestComics(unittest.TestCase):
         self.assertFalse("Foo" in [c.name for c in af15.characters])
         self.assertTrue("Steve Ditko" in [s.name for s in af15.creators])
         self.assertFalse("Abe Lincoln" in [s.name for s in af15.creators])
+        self.assertEqual(af15.prices.print, 0.1)
 
     def test_invalid_isbn(self):
         """Sometimes Marvel API sends number for isbn"""
         murpg = self.m.comics({"id": 1143}).comics[0]
         self.assertEqual(murpg.isbn, "785110283")
+        self.assertEqual(murpg.prices.print, 9.99)
 
     def test_invalid_diamond_code(self):
         """Sometimes Marvel API sends number for diamond code"""


### PR DESCRIPTION
Enabled the user to get a comics price if available.

Marvel's documentation suggest they also supply digital prices, but couldn't find any data to support that, so I add a stub comment if a case pops up sometime.

Any questions, don't hesitate to contact me. Thanks!