### PR TITLE
Add gh action for pypi publish

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,14 @@
+name: Python package
+on:
+  push:
+    tags:
+      - "v*.*.*"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Publish python poetry package
+        uses: JRubics/poetry-publish@v1.9
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
This gh action should work for publishing to PyPi when a new release is tagged. The only thing that might need your input is if you don't already have a PyPi Secret in the project setings. If you don't it's fairly straight-forward to setup:

- If you don't already have an API token from pypi, you'll need to generate one. Info on that can be found here: https://pypi.org/help/#apitoken

- Once you have that, head over to Setting->Secrets, and add the token with the name `PYPI_TOKEN`.

